### PR TITLE
Add API enablement note to error

### DIFF
--- a/impl/step_1_pubsub/create_subscription.py
+++ b/impl/step_1_pubsub/create_subscription.py
@@ -60,11 +60,12 @@ def main(argv):
                                                       topic_path)
     except PermissionDenied:
         error_message = ('PERMISSION DENIED: Check that the Pub/Sub API is '
-        'enabled in your project and that your service account was granted the '
-        'Pub/Sub Editor role. \n'
-        'Check API status at: %s \n'
-        'Check IAM roles at: %s ' % (PROJECT_PUBSUB_PAGE.format(project_id),
-                                     PROJECT_IAM_PAGE.format(project_id)))
+                         'enabled in your project and that your service '
+                         'account  was granted the Pub/Sub Editor role. \n'
+                         'Check API status at: %s \n'
+                         'Check IAM roles at: %s ' % (
+                             PROJECT_PUBSUB_PAGE.format(project_id),
+                             PROJECT_IAM_PAGE.format(project_id)))
         print error_message
         return
 

--- a/impl/step_1_pubsub/create_subscription.py
+++ b/impl/step_1_pubsub/create_subscription.py
@@ -58,9 +58,13 @@ def main(argv):
         subscription = subscriber.create_subscription(subscription_path,
                                                       topic_path)
     except PermissionDenied:
-        print 'PERMISSION DENIED: Check that your service account was granted '
-        print 'the Pub/Sub Editor role. Go to: %s' % PROJECT_IAM_PAGE.format(
-            project_id)
+        error_message = ('PERMISSION DENIED: Check that the Pub/Sub API is '
+        'enabled in your project and that your service account was granted '
+        'Pub/Sub Editor role. \n'
+        'Check API status at: %s \n'
+        'Check IAM roles at: %s ' % (PROJECT_PUBSUB_PAGE.format(project_id),
+                                     PROJECT_IAM_PAGE.format(project_id)))
+        print error_message
         return
 
     print 'Subscription created: {}'.format(subscription)

--- a/impl/step_1_pubsub/create_subscription.py
+++ b/impl/step_1_pubsub/create_subscription.py
@@ -59,7 +59,7 @@ def main(argv):
                                                       topic_path)
     except PermissionDenied:
         error_message = ('PERMISSION DENIED: Check that the Pub/Sub API is '
-        'enabled in your project and that your service account was granted '
+        'enabled in your project and that your service account was granted the '
         'Pub/Sub Editor role. \n'
         'Check API status at: %s \n'
         'Check IAM roles at: %s ' % (PROJECT_PUBSUB_PAGE.format(project_id),

--- a/impl/step_1_pubsub/create_subscription.py
+++ b/impl/step_1_pubsub/create_subscription.py
@@ -19,6 +19,7 @@ from google.cloud import pubsub_v1
 from google.oauth2 import service_account
 
 PROJECT_IAM_PAGE = 'https://console.cloud.google.com/iam-admin/iam?project={}'
+PROJECT_PUBSUB_PAGE = 'https://console.cloud.google.com/apis/library/pubsub.googleapis.com?project={}'
 
 TOPIC_PROJECT = 'cloudcommerceproc-prod'
 TOPIC_NAME_PREFIX = 'DEMO-'


### PR DESCRIPTION
We've seen two cases where `PermissionDenied` can get caught; wrong IAM roles on the SA, and the API just not being enabled at all for the specified project. Adding more info to our error message to be more helpful. 

Bonus: Made the whole error message one variable, so we don't have to call `print` multiple times.