### PR TITLE
Return a string instead of an int in _get_usage_for_product

### DIFF
--- a/impl/step_6_usage_reporting/report.py
+++ b/impl/step_6_usage_reporting/report.py
@@ -29,7 +29,7 @@ TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 def _get_usage_for_product():
     ### TODO: Get the usage since the last report time. ###
-    return 10
+    return '10'
 
 
 def _get_staging_discovery():


### PR DESCRIPTION
Service control will return a 200 OK if an `int64Value` is passed in as an int, but the usage will not actually counted. Changing this to be a string fixes that.

Reference:
https://cloud.google.com/service-infrastructure/docs/service-control/reference/rest/v1/MetricValueSet#MetricValue.FIELDS.int64_value